### PR TITLE
allow selecting fields with 'date and time' type as well

### DIFF
--- a/src/app/edit-form.js
+++ b/src/app/edit-form.js
@@ -204,7 +204,10 @@ class EditForm extends React.Component {
 
   loadAllScheduleFields = async () => {
     this.setState({availableScheduleFields: []});
-    const fields = await loadFieldsWithType(this.fetchYouTrack, 'date');
+    const fields = [
+      ...await loadFieldsWithType(this.fetchYouTrack, 'date'),
+      ...await loadFieldsWithType(this.fetchYouTrack, 'date and time'),
+    ];
     const availableScheduleFields = [];
     fields.forEach(field => {
       availableScheduleFields.push({label: field.name});


### PR DESCRIPTION
Thanks for the nice widget. 

To start resolving #7 I allowed the selection of 'date and time' and it seems to work fine. But I'm not entirely sure that does not have any corner cases. 

This does of course not enable displaying the time in the calendar.