### PR TITLE
Fix Black-on-Black color issue with hover-text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+dist
+node_modules
+*.zip
+*.bak

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "key": "due-dates-calendar",
   "name": "Due Dates Calendar",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Due Dates Calendar Widget for Youtrack Issues",
   "applicationName": "YouTrack",
   "author": "Oleg Bakhirev <oleg.bakhirev@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "due-dates-calendar",
-  "version": "1.0.0",
+  "version": "1.2.2",
   "private": true,
   "config": {
     "components": "./src",

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -259,6 +259,7 @@
 :global(.popup-header-text) {
   display: block;
   overflow: hidden;
+  color: white;
 
   width: calc(100% - 32px);
   margin-left: 8px;


### PR DESCRIPTION
This patch fixes an issue with black-on-very-dark-gray text when hovering over a calendar item.

Screenshot attached.

![image](https://user-images.githubusercontent.com/29494882/57962281-0a772300-78e3-11e9-8bb4-5abf0d995631.png)

I took the liberty of adding some stuff to .gitignore to exclude node_modules and dist. 
I also exclude .zip and .bak files.




