### PR TITLE
Fix "black on black" hover text with some CSS magic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+dist
+node_modules
+*.zip
+*.bak

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "key": "due-dates-calendar",
   "name": "Due Dates Calendar",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Due Dates Calendar Widget for Youtrack Issues",
   "applicationName": "YouTrack",
   "author": "Oleg Bakhirev <oleg.bakhirev@gmail.com>",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "key": "due-dates-calendar",
   "name": "Due Dates Calendar",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Due Dates Calendar Widget for Youtrack Issues",
   "applicationName": "YouTrack",
   "author": "Oleg Bakhirev <oleg.bakhirev@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "due-dates-calendar",
-  "version": "1.0.0",
+  "version": "1.2.2",
   "private": true,
   "config": {
     "components": "./src",

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -259,7 +259,10 @@
 :global(.popup-header-text) {
   display: block;
   overflow: hidden;
-  color: white;
+  
+  /* This value is the OPPOSITE color of our background */
+  color: rgb(255, 255, 255); 
+  mix-blend-mode: difference;
 
   width: calc(100% - 32px);
   margin-left: 8px;

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -259,6 +259,7 @@
 :global(.popup-header-text) {
   display: block;
   overflow: hidden;
+  color: white;
 
   width: calc(100% - 32px);
   margin-left: 8px;


### PR DESCRIPTION
Discovered my previous patch broke the "light" color scheme.   I came up with a purely-CSS fix that renders the text in a color OPPOSITE of the background.  "mix-blend-mode" is supported by most major browsers.

Fixed "Dark" theme looks like this 

![image](https://user-images.githubusercontent.com/29494882/57963697-26d08b00-78f6-11e9-8274-bd9718b842dc.png)

and Fixed "Light" theme looks like this

![image](https://user-images.githubusercontent.com/29494882/57963703-394ac480-78f6-11e9-99d3-9ce7da2377d7.png)

