### PR TITLE
Dark theme compatibility

### DIFF
--- a/src/app/app.css
+++ b/src/app/app.css
@@ -4,8 +4,7 @@
   margin: 0;
   padding: calc(unit * 2);
 
-  background: #fff;
-  background: var(--ring-content-background-color)
+  background: var(--ring-content-background-color);
 
   font-size: font-size;
 }
@@ -83,6 +82,7 @@
 :global(.rbc-show-more) {
   color: var(--ring-main-color);
 
+  border-radius: var(--ring-border-radius);
   font-size: 12px !important;
   font-weight: 400;
   text-decoration-line: none;
@@ -158,7 +158,12 @@
 }
 
 :global(.rbc-month-view) {
+  border-radius: var(--ring-border-radius);
   height: auto !important;
+}
+
+:global(.rbc-time-view) {
+  border-radius: var(--ring-border-radius);
 }
 
 :global(.event-container) {

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -5,6 +5,7 @@
   padding: calc(unit * 2);
 
   background: #fff;
+  background: var(--ring-content-background-color)
 
   font-size: font-size;
 }

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -162,12 +162,22 @@
 }
 
 :global(.rbc-month-view) {
+  border-color: var(--ring-line-color);
   border-radius: var(--ring-border-radius);
   height: auto !important;
 }
 
 :global(.rbc-time-view) {
+  border-color: var(--ring-line-color);
   border-radius: var(--ring-border-radius);
+}
+
+:global(.rbc-month-row+.rbc-month-row) {
+  border-top-color: var(--ring-line-color);
+}
+
+:global(.rbc-day-bg+.rbc-day-bg) {
+  border-left-color: var(--ring-line-color);
 }
 
 :global(.event-container) {
@@ -318,7 +328,12 @@
 }
 
 :global(.rbc-header) {
+  border-bottom-color: var(--ring-line-color);
   color: var(--ring-text-color);
+}
+
+:global(.rbc-header+.rbc-header) {
+  border-left-color: var(--ring-line-color);
 }
 
 :global(.rbc-date-cell.rbc-off-range) {

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -79,6 +79,10 @@
   float: left;
 }
 
+:global(.rbc-today) {
+  background-color: var(--ring-selected-background-color);
+}
+
 :global(.rbc-show-more) {
   color: var(--ring-main-color);
 
@@ -309,7 +313,16 @@
 }
 
 :global(.rbc-date-cell) {
+  color: var(--ring-text-color);
   padding-right: 8px;
+}
+
+:global(.rbc-header) {
+  color: var(--ring-text-color);
+}
+
+:global(.rbc-date-cell.rbc-off-range) {
+  color: var(--ring-hint-color);
 }
 
 :global(button.nav-button) {


### PR DESCRIPTION
When using the dark theme the calendar widget stays bright.

I used some variables from jetbrains to enhance the colors in the dark theme without destroying the bright theme.

A combined comparison how it looked before and after applying the fixes:

![Calendar](https://user-images.githubusercontent.com/571106/69037034-55cfd280-09e7-11ea-8863-b56b0e5c0c45.png)

I also added a border radius to the “show more” button and the “month view” / “time view” to be more consistent with the other widgets.